### PR TITLE
Fix url/href issue

### DIFF
--- a/contentscript.js
+++ b/contentscript.js
@@ -40,9 +40,9 @@ function sendURL(e)
     logourl = chrome.extension.getURL("logo_16_pending.png");
     e.currentTarget.childNodes[0].src = logourl;
     
-    var l = e.currentTarget.parentNode.getElementsByTagName("a");
+    var l = e.currentTarget.parentNode;
     
-    doSendURL(e.currentTarget.childNodes[0], mapTargetURL(l[0].href));
+    doSendURL(e.currentTarget.childNodes[0], mapTargetURL(l.href));
 }
 
 function doSendURL(target, url)

--- a/jsit_chrome_background.js
+++ b/jsit_chrome_background.js
@@ -82,24 +82,32 @@ function send_form(url, formData, sendResponse)
     http.open("POST", url, true);
 
     http.onreadystatechange = function() {
-        if(http.readyState == 4) 
+        if(http.readyState === XMLHttpRequest.DONE)
         {
-            resp = http.responseXML;
-            s = resp.getElementsByTagName("status")[0].innerHTML;
-            
-            if ( s != "SUCCESS" )
+            if(http.status === 200)
             {
-                m = urldecode(resp.getElementsByTagName("message")[0].innerHTML);
-                alert("Torrent upload failed!\n"+ m);
-                sendResponse("failure");
+                resp = http.responseXML;
+                s = resp.getElementsByTagName("status")[0].innerHTML;
+                
+                if ( s != "SUCCESS" )
+                {
+                    m = urldecode(resp.getElementsByTagName("message")[0].innerHTML);
+                    alert("Torrent upload failed!\n"+ m);
+                    sendResponse("failure");
+                }
+                else
+                {
+                    sendResponse("success");          
+                }
             }
             else
             {
-                sendResponse("success");          
+                alert("Torrent upload failed!\nIssue with connection/server");
+                sendResponse("failure");
             }
         }
     };
-  
+
     http.send(formData);
 }
 

--- a/jsit_tools.js
+++ b/jsit_tools.js
@@ -107,7 +107,8 @@ function do_add_single_button(l, url)
 	
     jsl.innerHTML = "<img width='16' height='16' src='" + logourl + "' title='Upload " + url + " to JSIT'/>";
 
-    l.parentNode.insertBefore(jsl, l.nextSibling);
+    //l.parentNode.insertBefore(jsl, l.nextSibling);
+    l.appendChild(jsl);
     //l.className = l.className;
     
     // See if icon is outside of visible area, move it then if it is             


### PR DESCRIPTION
Previously the jist icon was added as a sibling to the a tag. then when
clicked the url that was retrieved was the 1st a tag in the parent node.
This doesn't work as links could be in the same node and might have
clicked the 2nd jist icon...
So now jist icons are added to the a tag, and thus the parent node is
the same a tag the user wants and its href is used as the url.
fixes issue on extratorrent.cc, magnet links now work again (2nd link)
